### PR TITLE
chore: now LoadingOverlay appears after delay

### DIFF
--- a/src/components/LoadingOverlay.vue
+++ b/src/components/LoadingOverlay.vue
@@ -1,16 +1,29 @@
 <script setup lang="ts">
 import { useLoadingOverlayStore } from '@/stores/loading-overlay'
 
-defineProps({
-  overlayOpacity: { type: Number, default: 30 },
-})
 const state = useLoadingOverlayStore()
 </script>
 
 <template>
   <slot></slot>
-  <div class="fixed size-full flex justify-center" :class="[{ hidden: !state.isLoading }]">
-    <div class="size-full bg-black" :class="`opacity-${overlayOpacity}`"></div>
-    <div class="fixed loading loading-spinner self-center text-primary loading-xl"></div>
-  </div>
+  <transition name="fade">
+    <div v-if="state.isLoading" class="fixed size-full flex justify-center">
+      <div class="size-full bg-black opacity-30"></div>
+      <div class="fixed loading loading-spinner self-center text-primary loading-xl"></div>
+    </div>
+  </transition>
 </template>
+
+<style scoped>
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+.fade-enter-active {
+  transition: opacity 0.3s ease-out 150ms;
+}
+.fade-enter-to,
+.fade-leave-from {
+  opacity: 1;
+}
+</style>


### PR DESCRIPTION
This is done in order to not show the loading overlay when load times are really fast